### PR TITLE
Fix misalignment in protocol version 3.0.0.0

### DIFF
--- a/src/mocap_datapackets.cpp
+++ b/src/mocap_datapackets.cpp
@@ -151,7 +151,7 @@ void MoCapDataFormat::parse()
     }
 
     // skip mean marker error
-    seek(sizeof(float));
+    seek(sizeof(float) + 2);
   }
 
   // TODO: read skeletons


### PR DESCRIPTION
The parser for protocol version 3.0.0.0 is wrong. After reading the first rigid body, the parser becomes misaligned and fails to read any more rigid bodies.

Empirically, we've determined the error to be exactly two bytes, but hopefully a more durable approach can be taken in the future. This is for everyone who is tired of waiting.